### PR TITLE
Relax ActiveSupport version.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     saml_idp_metadata (0.3.3)
-      activesupport (< 7)
+      activesupport (< 8)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/saml_idp_metadata/parser.rb
+++ b/lib/saml_idp_metadata/parser.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_support/dependencies/autoload'
+require 'active_support'
 require 'active_support/core_ext'
 
 module SamlIdpMetadata

--- a/saml_idp_metadata.gemspec
+++ b/saml_idp_metadata.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '< 7'
+  spec.add_dependency 'activesupport', '< 8'
 
   spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
ActiveSupport version 7 has been released.
Therefore, I will relax the dependency version of this gem to make it compatible.