### PR TITLE
Drop Ruby 3.1 support due to EOL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,6 @@ workflows:
           matrix:
             parameters:
               ruby-version:
-                - "3.1"
                 - "3.2"
                 - "3.3"
                 - "3.4"

--- a/saml_idp_metadata.gemspec
+++ b/saml_idp_metadata.gemspec
@@ -6,7 +6,7 @@ require 'saml_idp_metadata/version'
 
 Gem::Specification.new do |spec|
   spec.name                  = 'saml_idp_metadata'
-  spec.required_ruby_version = '>= 3.1', '< 4'
+  spec.required_ruby_version = '>= 3.2', '< 4'
   spec.version               = SamlIdpMetadata::VERSION
   spec.authors               = ['tknzk']
   spec.email                 = ['info@tknzk.dev']


### PR DESCRIPTION
## 概要

Ruby 3.1がEOL（End of Life）になったため、テスト対象から削除します。

## 変更内容

- CircleCIのテストマトリックスからRuby 3.1を削除
- gemspecの`required_ruby_version`を`>= 3.2`に変更
- 現在のサポート対象: Ruby 3.2, 3.3, 3.4

## 注意事項

GitHub Actionsワークフローファイルの変更には特別な権限が必要なため、この変更は含まれていません。別途手動で`.github/workflows/ruby.yml`からRuby 3.1を削除する必要があります。

## 関連情報

- Ruby 3.1のEOLについて: https://www.ruby-lang.org/en/downloads/branches/

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author