### PR TITLE
Support Ruby 4.0 & Remove upper bound restriction on required_ruby_version

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,6 +16,7 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
+          - '4.0'
     container:
       image: rubylang/ruby:${{ matrix.ruby-version }}-dev-focal
 

--- a/saml_idp_metadata.gemspec
+++ b/saml_idp_metadata.gemspec
@@ -6,7 +6,7 @@ require 'saml_idp_metadata/version'
 
 Gem::Specification.new do |spec|
   spec.name                  = 'saml_idp_metadata'
-  spec.required_ruby_version = '>= 3.2', '< 4'
+  spec.required_ruby_version = '>= 3.2'
   spec.version               = SamlIdpMetadata::VERSION
   spec.authors               = ['tknzk']
   spec.email                 = ['info@tknzk.dev']


### PR DESCRIPTION
This pull request adds support for Ruby 4.0 to this gem by removing the upper bound restriction on required_ruby_version.
It also adds Ruby 4.0 to the test matrix.